### PR TITLE
fix(.github/workflows): bump setup-go action version to v2.1.4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1.1.2
+        uses: actions/setup-go@v2.1.4
         with:
           go-version: 1.14
         id: go


### PR DESCRIPTION
Update setup-go action to fix GitHub Actions workflow.